### PR TITLE
Change #PB_Window_ScreenCentered

### DIFF
--- a/PureBasicIDE/CompilerWindow.pb
+++ b/PureBasicIDE/CompilerWindow.pb
@@ -162,7 +162,7 @@ Procedure DisplayCompilerWindow()
     MacroErrorWindowEvents(#PB_Event_CloseWindow)
   EndIf
   
-  If OpenWindow(#WINDOW_Compiler, 0, 0, 200, 50, #ProductName$, #PB_Window_ScreenCentered | #PB_Window_TitleBar | #PB_Window_Invisible, WindowID(#WINDOW_Main))
+  If OpenWindow(#WINDOW_Compiler, 0, 0, 200, 50, #ProductName$, #PB_Window_WindowCentered | #PB_Window_TitleBar | #PB_Window_Invisible, WindowID(#WINDOW_Main))
     
     Container = ContainerGadget(#PB_Any, 5, 5, 190, 40, #PB_Container_Single)
     ; add a dummy text for size calculation


### PR DESCRIPTION
On Ubuntu when I have the IDE opened on Monitor 1st this tiny window appear on Monitor 2nd and when the IDE is opened on Monitor 2nd it appear on Monitor 2nd as well but not centered. It appear in the middle of both plus an offset to the right so the entire window is on Monitor 2nd. By experience with other PureBasic projects I have done this successfully to solve this problem and will don't have an impact on other operating system.